### PR TITLE
Update SQL Server container configuration and permissions

### DIFF
--- a/containers/docker-compose.yml
+++ b/containers/docker-compose.yml
@@ -21,3 +21,5 @@ services:
     environment:
       - ACCEPT_EULA=Y
       - SA_PASSWORD=Password123!
+    volumes:
+      - ./resources/sqlserver:/var/opt/mssql

--- a/containers/sqlserver/Dockerfile
+++ b/containers/sqlserver/Dockerfile
@@ -1,1 +1,23 @@
 FROM mcr.microsoft.com/mssql/server:2019-latest
+
+# 必要なパッケージをインストール
+USER root
+RUN apt-get update && apt-get install -y sudo
+
+# mssql ユーザーに sudo 権限を付与
+RUN echo 'mssql ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+# スクリプトをコンテナ内にコピー
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+
+# スクリプトに実行権限を付与
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+# mssqlユーザーに戻す
+USER mssql
+
+# エントリーポイントスクリプトを実行
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+
+# デフォルトのコマンド
+CMD ["/opt/mssql/bin/sqlservr"]

--- a/containers/sqlserver/entrypoint.sh
+++ b/containers/sqlserver/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# 一時的にrootユーザーに切り替えてパーミッションを設定
+sudo chown -R 10001:0 /var/opt/mssql
+sudo chmod -R 755 /var/opt/mssql
+
+# SQL Server の起動
+exec "$@"


### PR DESCRIPTION
This pull request updates the SQL Server container configuration and permissions. It includes the following changes:

- Adds a volume mapping for the SQL Server container to the local resources/sqlserver directory.

- Installs necessary packages and grants sudo permissions to the mssql user.

- Copies an entrypoint script into the container and sets execute permissions.

- Temporarily switches to the root user to set permissions for the /var/opt/mssql directory.

- Starts the SQL Server service.

These changes improve the configuration and permissions of the SQL Server container, ensuring proper functionality and security.