### PR TITLE
Update Docker Compose configuration for Secret container

### DIFF
--- a/containers/docker-compose.yml
+++ b/containers/docker-compose.yml
@@ -10,6 +10,8 @@ services:
       - "9002:80" # Temporary port for testing
     environment:
       - ASPNETCORE_ENVIRONMENT=Production
+    volumes:
+      - ./secret/bin:/app
 
   postgres:
     image: postgres:13.3

--- a/containers/secret/Dockerfile
+++ b/containers/secret/Dockerfile
@@ -1,4 +1,3 @@
 FROM mcr.microsoft.com/dotnet/aspnet:8.0
 WORKDIR /app
-COPY ./bin .
 ENTRYPOINT ["dotnet", "Web.dll"]


### PR DESCRIPTION
This pull request updates the Docker Compose configuration to include a volume mapping for the Secret container. This allows the container to access the files in the `./secret/bin` directory.