### PR TITLE
Update Docker Compose configuration for Secret container

### DIFF
--- a/containers/docker-compose.yml
+++ b/containers/docker-compose.yml
@@ -12,6 +12,8 @@ services:
       - ASPNETCORE_ENVIRONMENT=Production
     volumes:
       - ./secret/bin:/app
+    networks:
+      - secret_network
 
   postgres:
     image: postgres:13.3
@@ -36,3 +38,7 @@ services:
       - PGADMIN_DEFAULT_PASSWORD=Password123!
     volumes:
       - ./pgadmin/servers.json:/pgadmin4/servers.json
+
+networks:
+  secret_network:
+    external: true


### PR DESCRIPTION
This pull request updates the Docker Compose configuration for the Secret container. It adds a new network called `secret_network` and makes it external. This allows the Secret container to communicate with other containers on the same network.